### PR TITLE
Update list of required packages to add dependencies encountered buil…

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -771,7 +771,8 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev \
 	locales ncurses-base pixz dialog systemd-container udev lib32stdc++6 libc6-i386 lib32ncurses5 lib32tinfo5 \
-	bison libbison-dev flex libfl-dev cryptsetup gpgv1 gnupg1 cpio aria2 pigz dirmngr python3-distutils"
+	bison libbison-dev flex libfl-dev cryptsetup gpgv1 gnupg1 cpio aria2 pigz dirmngr python3-distutils \
+	ccache aria2 libusb-1.0-0-dev"
 
 	local codename=$(lsb_release -sc)
 


### PR DESCRIPTION
…ding a non standard build host

My attempts to build a Mint based build environment failed for lack of these packages. May not be needed on a supported build host, as they could be part of the default environment for Ubuntu. No Ubuntu host available to me test. They are clearly requirements for a build host though so adding them to the list here does no harm, and could help.

Extended the "local hostdeps" list to include ccache aria2 and libusb-1.0-0-dev

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
